### PR TITLE
fix: managing EXTRAVERSION allows an exact vermagic=4.4.302+ match

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -17,8 +17,11 @@ words:
   - Broadwell
   - Denverton
   - Grantley
+  - NETFILTER
+  - NFSD
   - Purley
   - Syno
   - allanc
   - chickenandpork
   - kernelconfig
+  - netfilter

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,17 @@
+# Building
+
+## Build and Test
+
+In order to repro the build-and-test I do, consider this:
+
+```
+mkdir -p $(pwd)/dist && \
+  docker build -t synology-docker-kernel-action:latest -f Dockerfile . && \
+  docker run -it --rm -v $(pwd)/dist:/github/workspace --entrypoint=/bin/bash synology-docker-kernel-action:latest \
+    -a denverton \
+    -v 7.2 \
+    -m "CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT" \
+    -n "CONFIG_NFSD CONFIG_NFS_FS" \
+    -t "net/ipv4/netfilter/ipt_REJECT.ko net/netfilter/xt_comment.ko"
+```
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,6 +125,7 @@ unpack() {
 merge() {
     echo "::group::Merging Config and Building"
     local -n t=$1
+    EXT=${2}
 
     ls -al /synobuild/usr/local/${t[4]}/scripts/kconfig/
 
@@ -134,6 +135,9 @@ merge() {
     # not setting (yet): KBUILD_BUILD_HOST
     # not setting (yet): KBUILD_BUILD_USER
     # not setting (yet): SOURCE_DATE_EPOCH
+
+    sed -ie "/^EXTRAVERSION =/ s/=.*\$/= ${EXT}/" /synobuild/usr/local/linux-4.4.x/Makefile
+    grep EXTRAVERSION /synobuild/usr/local/linux-4.4.x/Makefile
 
     chroot /synobuild bash -c 'cd /usr/local/linux-* && ./scripts/kconfig/merge_config.sh synoconfigs/denverton /localconfig && make modules'
     echo "::endgroup::"
@@ -177,7 +181,7 @@ stubbed_version_resolver "${PACKAGEARCH}" "${VERSION}" tarballs
 declare -p tarballs
 fetch tarballs
 unpack tarballs
-merge tarballs
+merge tarballs "+"
 manifest tarballs "${ARTIFACTS}"
 archive tarballs "/manifest" /github/workspace/${PACKAGEARCH}-${VERSION}.txz
 echo "archive=${PACKAGEARCH}-${VERSION}.txz" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
Loading the module was failing with:

```
$ sudo insmod net/netfilter/xt_comment.ko
insmod: ERROR: could not insert module net/netfilter/xt_comment.ko: Invalid module format
```

On examination, the kernel looks like this:
```
$ uname -a
Linux Soko 4.4.302+ #64570 SMP Thu Jul 20 00:07:05 CST 2023 x86_64 GNU/Linux synology_denverton_1819+
```
... whereas the module looks like this:
```
# strings /synobuild/usr/local/linux-4.4.x/net/netfilter/xt_comment.ko |grep '^vermagic'
vermagic=4.4.302 SMP mod_unload 
```
... so there's a "+" in the kernel that's missing in the module.  ...and YES, that's the one thing keeping these mods from loading.

Managing the EXTRAVERSION -- as a second parameter to the `merge` shell function -- is the smallest emans tog et that functional.  ...and yes, the module now loads.  I'm unsure how variable this will need to be, but for now, this unblocks me.