### PR TITLE
fix: add nf_reject_ipv4.ko for dependency in ipt_REJECT.ko

### DIFF
--- a/.github/workflows/denverton.yml
+++ b/.github/workflows/denverton.yml
@@ -13,7 +13,7 @@ jobs:
         uses: ./  # Uses this repo action
         id: build
         with:
-          artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/netfilter/xt_comment.ko
+          artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko
           dsm-version: '7.2'
           module-deactivate: CONFIG_NFSD CONFIG_NFS_FS
           module-modularize: CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT

--- a/BUILD.md
+++ b/BUILD.md
@@ -12,6 +12,21 @@ mkdir -p $(pwd)/dist && \
     -v 7.2 \
     -m "CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT" \
     -n "CONFIG_NFSD CONFIG_NFS_FS" \
-    -t "net/ipv4/netfilter/ipt_REJECT.ko net/netfilter/xt_comment.ko"
+    -t "net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko"
 ```
 
+## Iteratively evolve entrypoint.sh
+
+If you want to work on the entrypoint.sh, consider this:
+
+```
+mkdir -p $(pwd)/dist && \
+  docker build -t synology-docker-kernel-action:latest -f Dockerfile . && \
+  docker run -it --rm -v $(pwd)/dist:/github/workspace --entrypoint=/bin/bash synology-docker-kernel-action:latest
+GITHUB_OUTPUT=/proc/self/fd/1  /entrypoint.sh \
+  -a denverton \
+  -v 7.2 \
+  -m "CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT" \
+  -n "CONFIG_NFSD CONFIG_NFS_FS" \
+  -t "net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko"
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ A kernel-build silo for the 3-tarball-plus-linux Synology toolchain setup
 
 ## Inputs
 
+### `artifacts`
+
+This is the relative paths of modules to include in the artifact.  Although an array or list would
+be logical, currently this is a single string, space-separated.  For example,
+"net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko"
+
 ### `dsm-version`
 
 **defaults to 7.2**
@@ -20,6 +26,19 @@ Broadwell, Denverton.  case-insensitive, this value will be sanitized as needed 
 
 Denverton = denverton = DeNvErToN
 
+### `module-deactivate`
+
+This is a list of kernel symbols that should be deactivated in the build.  This is unusual for
+modules, but can be used to circumvent build failures unrelated to the modules you're packing up.
+Although an array or list would be logical, currently this is a single string, space-separated, all
+uppercase.  For example, "CONFIG_NFSD CONFIG_NFS_FS"
+
+### `module-modularize`
+
+This is a list of kernel symbols that should be activated as modules in the build.  Although an
+array or list would be logical, currently this is a single string, space-separated, all uppercase.
+For example, "CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT"
+
 ## Outputs
 
 ### `time`
@@ -30,6 +49,9 @@ The time the kernel was built (expecting other things to follow)
 
 uses: chickenandpork/synology-docker-kernel-action@v1
 with:
+  artifacts: net/ipv4/netfilter/ipt_REJECT.ko net/ipv4/netfilter/nf_reject_ipv4.ko net/netfilter/xt_comment.ko
   dsm-version: '7.2'
+  module-deactivate: CONFIG_NFSD CONFIG_NFS_FS
+  module-modularize: CONFIG_IP_NF_TARGET_REJECT CONFIG_NETFILTER_XT_MATCH_COMMENT
   package-arch: 'denverton'
 


### PR DESCRIPTION
During testing, the `ipt_REJECT.ko` showed dependency in `dmesg`:
```
[567365.732841] ipt_REJECT: Unknown symbol nf_send_reset (err 0)
[567365.738768] ipt_REJECT: Unknown symbol nf_send_unreach (err 0)
```

I found these in `net/ipv4/netfilter/nf_reject_ipv4.ko` with a basic `nm` on the modules.  Adding this to the artifact tarball, then `insmod` the `nf_reject_ipv4.ko` before the `insmod apt_REJECT.ko` successfully loaded.